### PR TITLE
Fixes after the first release

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ with open(filename) as users_csv:
 The `DataclassReader` internally uses the `DictReader` from the `csv` module to read the CSV file which means that you can pass the same arguments that you would pass to the `DictReader`. The complete argument list is shown below:
 
 ```python
-dataclass_csv.DataclassReader(f, cls_mapper, fieldnames=None, restkey=None, restval=None, dialect='excel', *args, **kwds)
+dataclass_csv.DataclassReader(f, cls, fieldnames=None, restkey=None, restval=None, dialect='excel', *args, **kwds)
 ```
 
 If you run this code you should see an output like this:
@@ -93,7 +93,7 @@ class User():
 And we modify the CSV file and remove the email for the user Astor:
 
 ```python
-Astor,Furtado,, 7
+Astor,, 7
 ```
 
 If we run the code we should see the output below:

--- a/dataclass_csv/dataclass_reader.py
+++ b/dataclass_csv/dataclass_reader.py
@@ -77,7 +77,8 @@ class DataclassReader:
                 return value
 
     def _process_row(self, row):
-        cls_instance = self.cls()
+
+        values = []
 
         for field in dataclasses.fields(self.cls):
 
@@ -93,9 +94,9 @@ class DataclassReader:
                     )
                 )
             else:
-                setattr(cls_instance, field.name, transformed_value)
+                values.append(transformed_value)
 
-        return cls_instance
+        return self.cls(*values)
 
     def __next__(self):
         row = next(self.reader)

--- a/dataclass_csv/dataclass_reader.py
+++ b/dataclass_csv/dataclass_reader.py
@@ -9,7 +9,7 @@ class DataclassReader:
     def __init__(
         self,
         f,
-        cls_mapper,
+        cls,
         fieldnames=None,
         restkey=None,
         restval=None,
@@ -21,10 +21,10 @@ class DataclassReader:
         if not f:
             raise ValueError('The f argument is required')
 
-        if cls_mapper is None or not dataclasses.is_dataclass(cls_mapper):
-            raise ValueError('cls_mapper argument needs to be a dataclass')
+        if cls is None or not dataclasses.is_dataclass(cls):
+            raise ValueError('cls argument needs to be a dataclass')
 
-        self.cls_mapper = cls_mapper
+        self.cls = cls
         self.optional_fields = self._get_optional_fields()
         self.field_mapping = {}
 
@@ -41,7 +41,7 @@ class DataclassReader:
     def _get_optional_fields(self):
         return [
             field.name
-            for field in dataclasses.fields(self.cls_mapper)
+            for field in dataclasses.fields(self.cls)
             if not isinstance(field.default, dataclasses._MISSING_TYPE)
         ]
 
@@ -77,9 +77,9 @@ class DataclassReader:
                 return value
 
     def _process_row(self, row):
-        mapped_user = self.cls_mapper()
+        cls_instance = self.cls()
 
-        for field in dataclasses.fields(self.cls_mapper):
+        for field in dataclasses.fields(self.cls):
 
             value = self._get_value(row, field)
 
@@ -93,9 +93,9 @@ class DataclassReader:
                     )
                 )
             else:
-                setattr(mapped_user, field.name, transformed_value)
+                setattr(cls_instance, field.name, transformed_value)
 
-        return mapped_user
+        return cls_instance
 
     def __next__(self):
         row = next(self.reader)


### PR DESCRIPTION
This PR removes the requirement of creating the dataclass with the option `init=False`. Another minor fix is the renaming of the `cls_mapper` argument to only `cls`.