### PR TITLE
Support for global and field metadata

### DIFF
--- a/dataclass_csv/__init__.py
+++ b/dataclass_csv/__init__.py
@@ -1,2 +1,2 @@
 from .dataclass_reader import DataclassReader
-from .decorators import dateformat
+from .decorators import dateformat, accept_whitespaces

--- a/dataclass_csv/decorators.py
+++ b/dataclass_csv/decorators.py
@@ -4,7 +4,15 @@ def dateformat(date_format):
         raise ValueError('Invalid value for the date_format argument')
 
     def func(cls):
-        cls.__date_format__ = date_format
+        cls.__dateformat__ = date_format
+        return cls
+
+    return func
+
+
+def accept_whitespaces():
+    def func(cls):
+        cls.__accept_whitespaces__ = True
         return cls
 
     return func

--- a/dataclass_csv/exceptions.py
+++ b/dataclass_csv/exceptions.py
@@ -1,2 +1,0 @@
-class MissingDecoratorError(Exception):
-    pass


### PR DESCRIPTION
Previously, there was a decorator `dateformat` to configure how the `datetime` strings would be passed into `datetime` objects to be assigned to properties in the class. However, there are times that the data in a CSV file can have different formats. This commit addresses this issue and read `dateformat` value from the `metadata` property of the `Field` object. This will allow specifying how the `datetime` string value should be parsed specifically for a property.

In the same way it has been also added a new decorator called `allow_whitespaces`, which will allow values containing only white spaces being assigned to the class string properties. This option can
also be set on a field level using the `metadata` property.

Last change as the removal of the custom exception classes that was not longer used.