### PR TITLE
Show error line number

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@
 
 Dataclass CSV makes working with CSV files easier and much better than working with Dicts. It uses Python's Dataclasses to store data of every row on the CSV file and also uses type annotations which enables proper type checking and validation.
 
+
+## Main features
+
+- Use `dataclasses` instead of dictionaries to represent the rows in the CSV file.
+- Take advantage of the `dataclass` properties type annotation. `DataclassReader` use the type annotation to perform validation of the data of the CSV file.
+- Automatic type conversion. `DataclassReader` convert date to `str`, `int`, `float`, `complex` and `datetime`
+- Helps you troubleshooting issues with the data in the CSV file. `DataclassReader` will show exactly in which line of the CSV file contain errors.
+- Extract only the data you need. It will only parse the properties defined in the `dataclass`
+- Familar syntax. It is used almost the same way as the `DictReader` in the standard library.
+- It uses `dataclass` features that lets you define metadata properties so the data can be parsed exactly the way you want.
+- Make the code cleaner. No more extra loops to convert data to the correct type, perform validation, set default values, the `DataclassReader` will do all this for you.
+
+
 ## Installation
 
 ```shell

--- a/dataclass_csv/__init__.py
+++ b/dataclass_csv/__init__.py
@@ -1,2 +1,3 @@
 from .dataclass_reader import DataclassReader
 from .decorators import dateformat, accept_whitespaces
+from .exceptions import CsvValueError

--- a/dataclass_csv/exceptions.py
+++ b/dataclass_csv/exceptions.py
@@ -1,0 +1,8 @@
+class CsvValueError(Exception):
+
+    def __init__(self, msg, line_number):
+        self.msg = msg
+        self.line_number = line_number
+
+    def __str__(self):
+        return f'Error: {self.msg} [CSV Line number: {self.line_number}]'

--- a/tests/test_csv_data_validation.py
+++ b/tests/test_csv_data_validation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dataclass_csv import DataclassReader
+from dataclass_csv import DataclassReader, CsvValueError
 
 from .mocks import User, UserWithDateFormatDecorator
 
@@ -9,7 +9,7 @@ def test_should_raise_error_str_to_int_prop(create_csv):
     csv_file = create_csv({'name': 'User1', 'age': 'wrong type'})
 
     with csv_file.open() as f:
-        with pytest.raises(ValueError):
+        with pytest.raises(CsvValueError):
             reader = DataclassReader(f, User)
             list(reader)
 
@@ -18,7 +18,7 @@ def test_should_raise_error_with_incorrect_dateformat(create_csv):
     csv_file = create_csv({'name': 'User1', 'create_date': '2018-12-07 10:00'})
 
     with csv_file.open() as f:
-        with pytest.raises(ValueError):
+        with pytest.raises(CsvValueError):
             reader = DataclassReader(f, UserWithDateFormatDecorator)
             list(reader)
 
@@ -27,7 +27,7 @@ def test_should_raise_error_when_required_value_is_missing(create_csv):
     csv_file = create_csv({'name': 'User1', 'age': None})
 
     with csv_file.open() as f:
-        with pytest.raises(ValueError):
+        with pytest.raises(CsvValueError):
             reader = DataclassReader(f, User)
             list(reader)
 
@@ -45,6 +45,6 @@ def test_should_raise_error_when_required_value_is_emptyspaces(create_csv):
     csv_file = create_csv({'name': '     ', 'age': 40})
 
     with csv_file.open() as f:
-        with pytest.raises(ValueError):
+        with pytest.raises(CsvValueError):
             reader = DataclassReader(f, User)
             list(reader)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dataclass_csv import DataclassReader
+from dataclass_csv import DataclassReader, CsvValueError
 
 from .mocks import (
     UserWithoutDateFormatDecorator,
@@ -17,7 +17,7 @@ def test_should_raise_error_without_dateformat(create_csv):
     csv_file = create_csv({'name': 'Test', 'create_date': '2018-12-09'})
 
     with csv_file.open('r') as f:
-        with pytest.raises(ValueError):
+        with pytest.raises(AttributeError):
             reader = DataclassReader(f, UserWithoutDateFormatDecorator)
             list(reader)
 
@@ -56,7 +56,7 @@ def test_should_raise_error_when_value_is_whitespaces(create_csv):
     csv_file = create_csv({'name': '     '})
 
     with csv_file.open('r') as f:
-        with pytest.raises(ValueError):
+        with pytest.raises(CsvValueError):
             reader = DataclassReader(f, UserWithoutAcceptWhiteSpacesDecorator)
             list(reader)
 


### PR DESCRIPTION
This will show exactly in which line of the CSV file the data didn't pass the validation.

Some other extras:

- Introduced a custom exception called `CsvValueError` which
contains a property `line_number`.

- Updated in the README file.