### PR TITLE
Fixed field lookup

### DIFF
--- a/dataclass_csv/__init__.py
+++ b/dataclass_csv/__init__.py
@@ -7,5 +7,5 @@ __all__ = [
     'DataclassReader',
     'dateformat',
     'accept_whitespaces',
-    'CsvValueError'
+    'CsvValueError',
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/dfurtado/dataclass-csv',
-    version='1.0.0',
+    version='1.0.1',
     zip_safe=False,
 )

--- a/tests/test_csv_data_validation.py
+++ b/tests/test_csv_data_validation.py
@@ -48,3 +48,30 @@ def test_should_raise_error_when_required_value_is_emptyspaces(create_csv):
         with pytest.raises(CsvValueError):
             reader = DataclassReader(f, User)
             list(reader)
+
+
+def test_csv_header_items_with_spaces_with_missing_props_raises_keyerror(create_csv):
+    csv_file = create_csv({'  name': 'User1'})
+
+    with csv_file.open() as f:
+        with pytest.raises(KeyError):
+            reader = DataclassReader(f, User)
+            items = list(reader)
+
+
+def test_csv_header_items_with_spaces_with_missing_value(create_csv):
+    csv_file = create_csv({'  name': 'User1', 'age   ': None})
+
+    with csv_file.open() as f:
+        with pytest.raises(CsvValueError):
+            reader = DataclassReader(f, User)
+            items = list(reader)
+
+
+def test_csv_header_items_with_spaces_with_prop_with_wrong_type(create_csv):
+    csv_file = create_csv({'  name': 'User1', 'age   ': 'this should be an int'})
+
+    with csv_file.open() as f:
+        with pytest.raises(CsvValueError):
+            reader = DataclassReader(f, User)
+            items = list(reader)

--- a/tests/test_dataclass_reader.py
+++ b/tests/test_dataclass_reader.py
@@ -60,3 +60,31 @@ def test_reader_values(create_csv):
 
         assert user2.name == 'User2'
         assert user2.age == 30
+
+def test_csv_header_items_with_spaces(create_csv):
+    csv_file = create_csv({'  name': 'User1', 'age   ': 40})
+
+    with csv_file.open() as f:
+        reader = DataclassReader(f, User)
+        items = list(reader)
+
+        assert items and len(items) > 0
+
+        user = items[0]
+
+        assert user.name == 'User1'
+        assert user.age == 40
+
+def test_csv_header_items_with_spaces_together_with_skipinitialspaces(create_csv):
+    csv_file = create_csv({'  name': 'User1', 'age   ': 40})
+
+    with csv_file.open() as f:
+        reader = DataclassReader(f, User, skipinitialspace=True)
+        items = list(reader)
+
+        assert items and len(items) > 0
+
+        user = items[0]
+
+        assert user.name == 'User1'
+        assert user.age == 40


### PR DESCRIPTION
The reader always strip the dict keys so it has a bigger possibility of matching with the name of the property of the dataclass.