### PR TITLE
Handling of fields with init set to False

### DIFF
--- a/dataclass_csv/dataclass_reader.py
+++ b/dataclass_csv/dataclass_reader.py
@@ -31,6 +31,7 @@ class DataclassReader:
         self.optional_fields = self._get_optional_fields()
         self.field_mapping = {}
 
+
         self.reader = csv.DictReader(
             f, fieldnames, restkey, restval, dialect, *args, **kwds
         )
@@ -134,6 +135,9 @@ class DataclassReader:
         values = []
 
         for field in dataclasses.fields(self.cls):
+            if not field.init:
+                continue
+
             try:
                 value = self._get_value(row, field)
             except ValueError as ex:

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -65,3 +65,17 @@ class DataclassWithBooleanValue:
 @dataclasses.dataclass
 class DataclassWithBooleanValueNoneDefault:
     boolValue: bool = None
+
+
+@dataclasses.dataclass
+class UserWithInitFalse:
+    firstname: str
+    lastname: str
+    age: int = dataclasses.field(init=False)
+
+
+@dataclasses.dataclass
+class UserWithInitFalseAndDefaultValue:
+    firstname: str
+    lastname: str
+    age: int = dataclasses.field(init=False, default=0)

--- a/tests/test_dataclass_reader.py
+++ b/tests/test_dataclass_reader.py
@@ -3,7 +3,13 @@ import dataclasses
 
 from dataclass_csv import DataclassReader, CsvValueError
 
-from .mocks import User, DataclassWithBooleanValue, DataclassWithBooleanValueNoneDefault
+from .mocks import (
+    User,
+    DataclassWithBooleanValue,
+    DataclassWithBooleanValueNoneDefault,
+    UserWithInitFalse,
+    UserWithInitFalseAndDefaultValue,
+)
 
 
 def test_reader_with_non_dataclass(create_csv):
@@ -114,19 +120,41 @@ def test_parse_bool_value_false(create_csv):
 def test_parse_bool_value_invalid(create_csv):
     csv_file = create_csv({'boolValue': 'notValidBoolean'})
     with csv_file.open() as f:
-        try:
+        with pytest.raises(CsvValueError):
             reader = DataclassReader(f, DataclassWithBooleanValue)
             list(reader)
-            assert False  # Should not be able to successfully parse
-        except CsvValueError:
-            pass
 
 
 def test_parse_bool_value_none_default(create_csv):
-    """Verify that blank/null values are parsed as None for optional fields"""
     csv_file = create_csv({'boolValue': ''})
     with csv_file.open() as f:
         reader = DataclassReader(f, DataclassWithBooleanValueNoneDefault)
         items = list(reader)
         dataclass_instance = items[0]
         assert dataclass_instance.boolValue is None
+
+
+def test_skip_dataclass_field_when_init_is_false(create_csv):
+    csv_file = create_csv({'firstname': 'User1', 'lastname': 'TestUser'})
+    with csv_file.open() as f:
+        reader = DataclassReader(f, UserWithInitFalse)
+        items = list(reader)
+
+
+def test_try_to_access_not_initialized_prop_raise_attr_error(create_csv):
+    csv_file = create_csv({'firstname': 'User1', 'lastname': 'TestUser'})
+    with csv_file.open() as f:
+        reader = DataclassReader(f, UserWithInitFalse)
+        items = list(reader)
+        with pytest.raises(AttributeError):
+            user = items[0]
+            user_age = user.age
+
+
+def test_try_to_access_not_initialized_prop_with_default_value(create_csv):
+    csv_file = create_csv({'firstname': 'User1', 'lastname': 'TestUser'})
+    with csv_file.open() as f:
+        reader = DataclassReader(f, UserWithInitFalseAndDefaultValue)
+        items = list(reader)
+        user = items[0]
+        assert user.age == 0


### PR DESCRIPTION
When a field in the dataclass is set to False it means that field won't be added to the list of arguments in the class initializer.

This PR handle cases where a field has init set to False. The DataclassReader will skip these fields and won't add them to the argument list when initializing the class.

Default values and default factories will be handled by the dataclass implementation.

Resolve issue: https://github.com/dfurtado/dataclass-csv/issues/9