### PR TITLE
Handle Optional typing annotations.

### DIFF
--- a/dataclass_csv/dataclass_reader.py
+++ b/dataclass_csv/dataclass_reader.py
@@ -3,6 +3,7 @@ import csv
 
 from datetime import datetime
 from distutils.util import strtobool
+from typing import Union
 
 from .field_mapper import FieldMapper
 from .exceptions import CsvValueError
@@ -145,7 +146,22 @@ class DataclassReader:
                 values.append(None)
                 continue
 
-            if field.type is datetime:
+            field_type = field.type
+            # Special handling for Optional (Union of a single real type and None)
+            if (
+                # The first part of the condition is for Python < 3.8
+                type(field_type).__name__ == '_Union'
+                # The second part of the condition is for Python >= 3.8
+                or '__origin__' in field_type.__dict__
+                and field_type.__origin__ is Union
+            ):
+                real_types = [
+                    t for t in field_type.__args__ if t is not type(None)
+                ]
+                if len(real_types) == 1:
+                    field_type = real_types[0]
+
+            if field_type is datetime:
                 try:
                     transformed_value = self._parse_date_value(field, value)
                 except ValueError as ex:
@@ -156,7 +172,7 @@ class DataclassReader:
                     values.append(transformed_value)
                     continue
 
-            if field.type is bool:
+            if field_type is bool:
                 try:
                     transformed_value = (
                         value
@@ -172,7 +188,7 @@ class DataclassReader:
                     continue
 
             try:
-                transformed_value = field.type(value)
+                transformed_value = field_type(value)
             except ValueError:
                 raise CsvValueError(
                     (

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 from dataclass_csv import dateformat, accept_whitespaces
 
+from typing import Optional
+
 
 @dataclasses.dataclass
 class User:
@@ -65,3 +67,10 @@ class DataclassWithBooleanValue:
 @dataclasses.dataclass
 class DataclassWithBooleanValueNoneDefault:
     boolValue: bool = None
+
+
+@dataclasses.dataclass
+class UserWithOptionalAge:
+    name: str
+    age: Optional[int]
+

--- a/tests/test_dataclass_reader.py
+++ b/tests/test_dataclass_reader.py
@@ -3,7 +3,7 @@ import dataclasses
 
 from dataclass_csv import DataclassReader, CsvValueError
 
-from .mocks import User, DataclassWithBooleanValue, DataclassWithBooleanValueNoneDefault
+from .mocks import User, UserWithOptionalAge, DataclassWithBooleanValue, DataclassWithBooleanValueNoneDefault
 
 
 def test_reader_with_non_dataclass(create_csv):
@@ -130,3 +130,13 @@ def test_parse_bool_value_none_default(create_csv):
         items = list(reader)
         dataclass_instance = items[0]
         assert dataclass_instance.boolValue is None
+
+
+def test_reader_with_optional_types(create_csv):
+    csv_file = create_csv({'name': 'User', 'age': 40})
+
+    with csv_file.open() as f:
+        reader = DataclassReader(f, UserWithOptionalAge)
+        list(reader)
+
+


### PR DESCRIPTION
The use of the Optional annotation is necessary when the value of None is
allowed for a field, otherwise type checkers will complain. This change adds
support for this use case.