### PR TITLE
Fix for datetime fields with default datetime val

### DIFF
--- a/dataclass_csv/dataclass_reader.py
+++ b/dataclass_csv/dataclass_reader.py
@@ -117,6 +117,9 @@ class DataclassReader:
     def _parse_date_value(self, field, date_value):
         dateformat = self._get_metadata_option(field, 'dateformat')
 
+        if not isinstance(date_value, str):
+            return date_value
+
         if not dateformat:
             raise AttributeError(
                 (
@@ -129,7 +132,6 @@ class DataclassReader:
                     '{\'dateformat\': <date_format>})`.'
                 )
             )
-
         return datetime.strptime(date_value, dateformat)
 
     def _process_row(self, row):
@@ -203,7 +205,6 @@ class DataclassReader:
                 ) from None
             else:
                 values.append(transformed_value)
-
         return self.cls(*values)
 
     def __next__(self):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -87,3 +87,7 @@ class UserWithOptionalAge:
     name: str
     age: Optional[int]
 
+@dataclasses.dataclass
+class UserWithDefaultDatetimeField:
+    name: str
+    birthday: datetime = datetime.now()

--- a/tests/test_dataclass_reader.py
+++ b/tests/test_dataclass_reader.py
@@ -1,6 +1,7 @@
 import pytest
 import dataclasses
 
+from datetime import datetime
 from dataclass_csv import DataclassReader, CsvValueError
 
 from .mocks import (
@@ -10,6 +11,7 @@ from .mocks import (
     DataclassWithBooleanValueNoneDefault,
     UserWithInitFalse,
     UserWithInitFalseAndDefaultValue,
+    UserWithDefaultDatetimeField,
 )
 
 
@@ -167,3 +169,12 @@ def test_reader_with_optional_types(create_csv):
     with csv_file.open() as f:
         reader = DataclassReader(f, UserWithOptionalAge)
         list(reader)
+
+def test_reader_with_datetime_default_value(create_csv):
+    csv_file = create_csv({'name': 'User', 'bithday': ''})
+
+    with csv_file.open() as f:
+        reader = DataclassReader(f, UserWithDefaultDatetimeField)
+        items = list(reader)
+        assert len(items) > 0
+        assert isinstance(items[0].birthday, datetime)


### PR DESCRIPTION
Issue [#20](https://github.com/dfurtado/dataclass-csv/issues/20) reports a problem when a dataclass has a datetime field with a default value that is already datetime. The datetime parser tries to parse the datetime object as if it would be a string.