### PR TITLE
Raise an error when mapped column is not found

### DIFF
--- a/dataclass_csv/__init__.py
+++ b/dataclass_csv/__init__.py
@@ -35,13 +35,7 @@ Basic Usage:
 
 from .dataclass_reader import DataclassReader
 from .decorators import dateformat, accept_whitespaces
-from .exceptions import CsvValueError, MappedColumnNotFoundError
+from .exceptions import CsvValueError
 
 
-__all__ = [
-    'DataclassReader',
-    'dateformat',
-    'accept_whitespaces',
-    'CsvValueError',
-    'MappedColumnNotFoundError',
-]
+__all__ = ['DataclassReader', 'dateformat', 'accept_whitespaces', 'CsvValueError']

--- a/dataclass_csv/__init__.py
+++ b/dataclass_csv/__init__.py
@@ -35,7 +35,7 @@ Basic Usage:
 
 from .dataclass_reader import DataclassReader
 from .decorators import dateformat, accept_whitespaces
-from .exceptions import CsvValueError
+from .exceptions import CsvValueError, MappedColumnNotFoundError
 
 
 __all__ = [
@@ -43,4 +43,5 @@ __all__ = [
     'dateformat',
     'accept_whitespaces',
     'CsvValueError',
+    'MappedColumnNotFoundError',
 ]

--- a/dataclass_csv/dataclass_reader.py
+++ b/dataclass_csv/dataclass_reader.py
@@ -6,7 +6,7 @@ from distutils.util import strtobool
 from typing import Union
 
 from .field_mapper import FieldMapper
-from .exceptions import CsvValueError, MappedColumnNotFoundError
+from .exceptions import CsvValueError
 
 
 class DataclassReader:
@@ -31,7 +31,6 @@ class DataclassReader:
         self.cls = cls
         self.optional_fields = self._get_optional_fields()
         self.field_mapping = {}
-
 
         self.reader = csv.DictReader(
             f, fieldnames, restkey, restval, dialect, *args, **kwds
@@ -60,9 +59,7 @@ class DataclassReader:
         )
 
     def _get_possible_keys(self, fieldname, row):
-        possible_keys = list(
-            filter(lambda x: x.strip() == fieldname, row.keys())
-        )
+        possible_keys = list(filter(lambda x: x.strip() == fieldname, row.keys()))
         if possible_keys:
             return possible_keys[0]
 
@@ -87,14 +84,10 @@ class DataclassReader:
             if field.name in self.optional_fields:
                 return self._get_default_value(field)
             else:
+                keyerror_message = f'The value for the column `{field.name}` is missing in the CSV file.'
                 if is_field_mapped:
-                    raise MappedColumnNotFoundError(
-                        f'The mapped column `{key}` is missing in the CSV file'
-                    )
-                else:
-                    raise KeyError(
-                        f'The value `{field.name}` is missing in the CSV file.'
-                    )
+                    keyerror_message = f'The value for the mapped column `{key}` is missing in the CSV file'
+                raise KeyError(keyerror_message)
         else:
             if not value and field.name in self.optional_fields:
                 return self._get_default_value(field)
@@ -151,9 +144,7 @@ class DataclassReader:
             try:
                 value = self._get_value(row, field)
             except ValueError as ex:
-                raise CsvValueError(
-                    ex, line_number=self.reader.line_num
-                ) from None
+                raise CsvValueError(ex, line_number=self.reader.line_num) from None
 
             if not value and field.default is None:
                 values.append(None)
@@ -168,9 +159,7 @@ class DataclassReader:
                 or '__origin__' in field_type.__dict__
                 and field_type.__origin__ is Union
             ):
-                real_types = [
-                    t for t in field_type.__args__ if t is not type(None)
-                ]
+                real_types = [t for t in field_type.__args__ if t is not type(None)]
                 if len(real_types) == 1:
                     field_type = real_types[0]
 
@@ -178,9 +167,7 @@ class DataclassReader:
                 try:
                     transformed_value = self._parse_date_value(field, value)
                 except ValueError as ex:
-                    raise CsvValueError(
-                        ex, line_number=self.reader.line_num
-                    ) from None
+                    raise CsvValueError(ex, line_number=self.reader.line_num) from None
                 else:
                     values.append(transformed_value)
                     continue
@@ -193,9 +180,7 @@ class DataclassReader:
                         else strtobool(str(value).strip()) == 1
                     )
                 except ValueError as ex:
-                    raise CsvValueError(
-                        ex, line_number=self.reader.line_num
-                    ) from None
+                    raise CsvValueError(ex, line_number=self.reader.line_num) from None
                 else:
                     values.append(transformed_value)
                     continue
@@ -226,7 +211,5 @@ class DataclassReader:
         :param csv_fieldname: The name of the CSV field
         """
         return FieldMapper(
-            lambda property_name: self._add_to_mapping(
-                property_name, csv_fieldname
-            )
+            lambda property_name: self._add_to_mapping(property_name, csv_fieldname)
         )

--- a/dataclass_csv/exceptions.py
+++ b/dataclass_csv/exceptions.py
@@ -7,7 +7,3 @@ class CsvValueError(Exception):
 
     def __str__(self):
         return f'{self.error} [CSV Line number: {self.line_number}]'
-
-
-class MappedColumnNotFoundError(Exception):
-    pass

--- a/dataclass_csv/exceptions.py
+++ b/dataclass_csv/exceptions.py
@@ -7,3 +7,7 @@ class CsvValueError(Exception):
 
     def __str__(self):
         return f'{self.error} [CSV Line number: {self.line_number}]'
+
+
+class MappedColumnNotFoundError(Exception):
+    pass

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -108,3 +108,10 @@ class SSN:
 class UserWithSSN:
     name: str
     ssn: SSN
+
+
+@dataclasses.dataclass
+class UserWithEmail:
+    name: str
+    email: str
+

--- a/tests/test_dataclass_reader.py
+++ b/tests/test_dataclass_reader.py
@@ -2,7 +2,7 @@ import pytest
 import dataclasses
 
 from datetime import datetime
-from dataclass_csv import DataclassReader, CsvValueError, MappedColumnNotFoundError
+from dataclass_csv import DataclassReader, CsvValueError
 
 from .mocks import (
     User,
@@ -205,7 +205,7 @@ def test_raise_error_when_mapped_column_not_found(create_csv):
     csv_file = create_csv({'name': 'User1', 'e-mail': 'test@test.com'})
 
     with csv_file.open() as f:
-        with pytest.raises(MappedColumnNotFoundError):
+        with pytest.raises(KeyError, match='The value for the mapped column `e_mail` is missing in the CSV file'):
             reader = DataclassReader(f, UserWithEmail)
             reader.map('e_mail').to('email')
             list(reader)
@@ -215,7 +215,7 @@ def test_raise_error_when_field_not_found(create_csv):
     csv_file = create_csv({'name': 'User1', 'e-mail': 'test@test.com'})
 
     with csv_file.open() as f:
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match='The value for the column `email` is missing in the CSV file.'):
             reader = DataclassReader(f, UserWithEmail)
             list(reader)
 


### PR DESCRIPTION
Improve the error message when a mapped column is not found in the CSV file. A new exception type 'MappedColumnNotFoundError' has been introduced for these cases.

Added additional tests to reproduce two different scenarios, the first when a mapped column is not found and the second and a non-mapped column is not found.

Related issue: https://github.com/dfurtado/dataclass-csv/issues/34