### PR TITLE
Validate duplicated header 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ dataclass_csv.DataclassReader(
 )
 ```
 
+All keyword arguments support by `DictReader` are supported by the `DataclassReader`, with the addition of:
+
+`validate_header` - The `DataclassReader` will raise a `ValueError` if the CSV file cointain columns with the same name. This
+validation is performed to avoid data being overwritten. To skip this validation set `validate_header=False` when creating a
+instance of the `DataclassReader`, see an example below:
+
+```python
+reader = DataclassReader(f, User, validate_header=False)
+```
+
 If you run this code you should see an output like this:
 
 ```python

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,20 +5,20 @@ import pytest
 
 @pytest.fixture()
 def create_csv(tmpdir_factory):
-    def func(data, filename='user.csv', factory=tmpdir_factory):
+    def func(data, fieldnames=None, filename="user.csv", factory=tmpdir_factory):
 
         assert data
 
-        file = tmpdir_factory.mktemp('data').join(filename)
+        file = tmpdir_factory.mktemp("data").join(filename)
 
         row = data[0] if isinstance(data, list) else data
 
-        with file.open('w') as f:
-            writer = DictWriter(f, fieldnames=row.keys())
+        header = fieldnames if fieldnames is not None else row.keys()
+
+        with file.open("w") as f:
+            writer = DictWriter(f, fieldnames=header)
             writer.writeheader()
-            addrow = (
-                writer.writerows if isinstance(data, list) else writer.writerow
-            )
+            addrow = writer.writerows if isinstance(data, list) else writer.writerow
             addrow(data)
 
         return file

--- a/tests/test_dataclass_reader.py
+++ b/tests/test_dataclass_reader.py
@@ -225,3 +225,26 @@ def test_raise_error_when_field_not_found(create_csv):
         ):
             reader = DataclassReader(f, UserWithEmail)
             list(reader)
+
+
+def test_raise_error_when_duplicate_header_items(create_csv):
+    csv_file = create_csv(
+        {"name": "User1", "email": "test@test.com"},
+        fieldnames=["name", "email", "name"],
+    )
+
+    with csv_file.open() as f:
+        with pytest.raises(ValueError):
+            reader = DataclassReader(f, UserWithEmail)
+            list(reader)
+
+
+def test_skip_header_validation(create_csv):
+    csv_file = create_csv(
+        {"name": "User1", "email": "test@test.com"},
+        fieldnames=["name", "email", "name"],
+    )
+
+    with csv_file.open() as f:
+        reader = DataclassReader(f, UserWithEmail, validate_header=False)
+        list(reader)


### PR DESCRIPTION
This PR adds validation when a CSV file contain duplication of headers

For example, give the following CSV file with the contents below:

```csv
name, email,age,name
User1,user@test.com,40,User2
```

In this case the value that is going to be set a property `name` in a dataclass is `User2`. It will overwrite the first value `User1`. 

To avoid this problem, and data inconsistency, a validation is performed right when creating a instance of `DataclassReader`. If there are duplication a `ValueError` exception will be raised, showing which fields are duplicated.

In addition to the validation, it has been added support for skipping the validation, that is achieved by passing a keyword argument to the `DataclassReader`, like so:

```python
reader = DataclassReader(f, User, validate_header=False)
```
This closes the issue: https://github.com/dfurtado/dataclass-csv/issues/10




