### PR TITLE
Fix dataclass initialization

### DIFF
--- a/dataclass_csv/dataclass_reader.py
+++ b/dataclass_csv/dataclass_reader.py
@@ -178,7 +178,7 @@ class DataclassReader:
         return datetime.strptime(date_value, dateformat)
 
     def _process_row(self, row):
-        values = []
+        values = dict()
 
         for field in dataclasses.fields(self._cls):
             if not field.init:
@@ -190,7 +190,7 @@ class DataclassReader:
                 raise CsvValueError(ex, line_number=self._reader.line_num) from None
 
             if not value and field.default is None:
-                values.append(None)
+                values[field.name] = None
                 continue
 
             field_type = self.type_hints[field.name]
@@ -206,7 +206,7 @@ class DataclassReader:
                 except ValueError as ex:
                     raise CsvValueError(ex, line_number=self._reader.line_num) from None
                 else:
-                    values.append(transformed_value)
+                    values[field.name] = transformed_value
                     continue
 
             if field_type is bool:
@@ -219,7 +219,7 @@ class DataclassReader:
                 except ValueError as ex:
                     raise CsvValueError(ex, line_number=self._reader.line_num) from None
                 else:
-                    values.append(transformed_value)
+                    values[field.name] = transformed_value
                     continue
 
             try:
@@ -233,8 +233,8 @@ class DataclassReader:
                     line_number=self._reader.line_num,
                 ) from e
             else:
-                values.append(transformed_value)
-        return self._cls(*values)
+                values[field.name] = transformed_value
+        return self._cls(**values)
 
     def __next__(self):
         row = next(self._reader)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -122,3 +122,9 @@ class UserWithSSN:
 class UserWithEmail:
     name: str
     email: str
+
+
+@dataclasses.dataclass
+class UserWithOptionalEmail:
+    name: str
+    email: str = "not specified"

--- a/tests/test_dataclass_reader.py
+++ b/tests/test_dataclass_reader.py
@@ -248,3 +248,13 @@ def test_skip_header_validation(create_csv):
     with csv_file.open() as f:
         reader = DataclassReader(f, UserWithEmail, validate_header=False)
         list(reader)
+
+def test_dt_different_order_as_csv(create_csv):
+    csv_file = create_csv(
+        {"email": "test@test.com", "name": "User1"},
+        fieldnames=["email", "name",],
+    )
+
+    with csv_file.open() as f:
+       reader = DataclassReader(f, UserWithEmail)
+       list(reader)

--- a/tests/test_dataclass_reader.py
+++ b/tests/test_dataclass_reader.py
@@ -250,15 +250,19 @@ def test_skip_header_validation(create_csv):
         reader = DataclassReader(f, UserWithEmail, validate_header=False)
         list(reader)
 
+
 def test_dt_different_order_as_csv(create_csv):
     csv_file = create_csv(
         {"email": "test@test.com", "name": "User1"},
-        fieldnames=["email", "name",],
+        fieldnames=[
+            "email",
+            "name",
+        ],
     )
 
     with csv_file.open() as f:
-       reader = DataclassReader(f, UserWithEmail)
-       list(reader)
+        reader = DataclassReader(f, UserWithEmail)
+        list(reader)
 
 
 def test_dt_different_order_as_csv_and_option_field(create_csv):
@@ -269,9 +273,12 @@ def test_dt_different_order_as_csv_and_option_field(create_csv):
 
     csv_file = create_csv(
         data,
-        fieldnames=["email", "name",],
+        fieldnames=[
+            "email",
+            "name",
+        ],
     )
 
     with csv_file.open() as f:
-       reader = DataclassReader(f, UserWithOptionalEmail)
-       list(reader)
+        reader = DataclassReader(f, UserWithOptionalEmail)
+        list(reader)

--- a/tests/test_dataclass_reader.py
+++ b/tests/test_dataclass_reader.py
@@ -15,6 +15,7 @@ from .mocks import (
     UserWithSSN,
     SSN,
     UserWithEmail,
+    UserWithOptionalEmail,
 )
 
 
@@ -257,4 +258,20 @@ def test_dt_different_order_as_csv(create_csv):
 
     with csv_file.open() as f:
        reader = DataclassReader(f, UserWithEmail)
+       list(reader)
+
+
+def test_dt_different_order_as_csv_and_option_field(create_csv):
+    data = [
+        {"email": "test@test.com", "name": "User1"},
+        {"name": "User1"},
+    ]
+
+    csv_file = create_csv(
+        data,
+        fieldnames=["email", "name",],
+    )
+
+    with csv_file.open() as f:
+       reader = DataclassReader(f, UserWithOptionalEmail)
        list(reader)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -14,26 +14,26 @@ from .mocks import (
 
 
 def test_should_raise_error_without_dateformat(create_csv):
-    csv_file = create_csv({'name': 'Test', 'create_date': '2018-12-09'})
+    csv_file = create_csv({"name": "Test", "create_date": "2018-12-09"})
 
-    with csv_file.open('r') as f:
+    with csv_file.open("r") as f:
         with pytest.raises(AttributeError):
             reader = DataclassReader(f, UserWithoutDateFormatDecorator)
             list(reader)
 
 
 def test_shold_not_raise_error_when_using_dateformat_decorator(create_csv):
-    csv_file = create_csv({'name': 'Test', 'create_date': '2018-12-09'})
+    csv_file = create_csv({"name": "Test", "create_date": "2018-12-09"})
 
-    with csv_file.open('r') as f:
+    with csv_file.open("r") as f:
         reader = DataclassReader(f, UserWithDateFormatDecorator)
         list(reader)
 
 
 def test_shold_not_raise_error_when_dateformat_metadata(create_csv):
-    csv_file = create_csv({'name': 'Test', 'create_date': '2018-12-09'})
+    csv_file = create_csv({"name": "Test", "create_date": "2018-12-09"})
 
-    with csv_file.open('r') as f:
+    with csv_file.open("r") as f:
         reader = DataclassReader(f, UserWithDateFormatMetadata)
         list(reader)
 
@@ -41,43 +41,43 @@ def test_shold_not_raise_error_when_dateformat_metadata(create_csv):
 def test_use_decorator_when_metadata_is_not_defined(create_csv):
     csv_file = create_csv(
         {
-            'name': 'Test',
-            'birthday': '1977-08-26',
-            'create_date': '2018-12-09 11:11',
+            "name": "Test",
+            "birthday": "1977-08-26",
+            "create_date": "2018-12-09 11:11",
         }
     )
 
-    with csv_file.open('r') as f:
+    with csv_file.open("r") as f:
         reader = DataclassReader(f, UserWithDateFormatDecoratorAndMetadata)
         list(reader)
 
 
 def test_should_raise_error_when_value_is_whitespaces(create_csv):
-    csv_file = create_csv({'name': '     '})
+    csv_file = create_csv({"name": "     "})
 
-    with csv_file.open('r') as f:
+    with csv_file.open("r") as f:
         with pytest.raises(CsvValueError):
             reader = DataclassReader(f, UserWithoutAcceptWhiteSpacesDecorator)
             list(reader)
 
 
 def test_should_not_raise_error_when_value_is_whitespaces(create_csv):
-    csv_file = create_csv({'name': '     '})
+    csv_file = create_csv({"name": "     "})
 
-    with csv_file.open('r') as f:
+    with csv_file.open("r") as f:
         reader = DataclassReader(f, UserWithAcceptWhiteSpacesDecorator)
         data = list(reader)
 
         user = data[0]
-        assert user.name == '     '
+        assert user.name == "     "
 
 
 def test_should_not_raise_error_when_using_meta_accept_whitespaces(create_csv):
-    csv_file = create_csv({'name': '     '})
+    csv_file = create_csv({"name": "     "})
 
-    with csv_file.open('r') as f:
+    with csv_file.open("r") as f:
         reader = DataclassReader(f, UserWithAcceptWhiteSpacesMetadata)
         data = list(reader)
 
         user = data[0]
-        assert user.name == '     '
+        assert user.name == "     "


### PR DESCRIPTION
This PR fixes a issue where the initialization of dataclass instance was dependent of the order which the columns of the CSV file was defined. For instance, a dataclass defined as:

``` python
@dataclass
class User:
    name: str
    email: str = "not specified"
```
The definition above required the CSV file to have the first column `name` and the second  `email`, causing error or inconsistent data set the the dataclass fields.

Related issue: https://github.com/dfurtado/dataclass-csv/issues/47



